### PR TITLE
Fix typo in image name texive -> texlive

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ GitHub Container Registry からインストールできます。
 ### GitHub Container Registry
 
 ```bash
-docker pull ghcr.io/smkwlab/texive-ja-textlint:latest
-docker image tag ghcr.io/smkwlab/texive-ja-textlint:latest smkwlab/texive-ja-textlint:latest
+docker pull ghcr.io/smkwlab/texlive-ja-textlint:latest
+docker image tag ghcr.io/smkwlab/texlive-ja-textlint:latest smkwlab/texlive-ja-textlint:latest
 ```
 
 ## Usage / 使い方
 
 ```bash
-$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texive-ja-textlint:latest \
+$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:latest \
     sh -c 'latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex'
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,7 @@ This article is in Japanese only.
 
 ## latexmk を使う
 
-smkwlab/texive-ja-textlint には、latexmk と textlint がインストールされています
+smkwlab/texlive-ja-textlint には、latexmk と textlint がインストールされています
 
 例えば、upLaTeX でビルドしたい場合、次のように `latexmkrc` ファイルを作ると、`latexmk` コマンドだけでビルドできます
 
@@ -26,20 +26,20 @@ $pdf_mode = 3;
 ```
 
 ```bash
-$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texive-ja-textlint:latest \
+$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:latest \
     sh -c 'latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex'
 ```
 
 ## VSCode LaTeX Workshop で使う
 
-smkwlab/texive-ja-textlint は、[LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) で使えます
+smkwlab/texlive-ja-textlint は、[LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) で使えます
 
 「latexmk を使う」を参考に `latexmkrc` を用意したあと、次のように VSCode の設定を書き換えます
 
 ```json
 {
   "latex-workshop.docker.enabled": true,
-  "latex-workshop.docker.image.latex": "smkwlab/texive-ja-textlint:latest",
+  "latex-workshop.docker.image.latex": "smkwlab/texlive-ja-textlint:latest",
   "latex-workshop.latex.tools": [
     {
       "name": "latexmk",
@@ -117,14 +117,14 @@ $ wget https://github.com/zr-tex8r/PXchfon-extras/raw/master/pxchfon-extras.def
 
 ## イメージを拡張する
 
-smkwlab/texive-ja-textlint には、最小限のパッケージしかインストールされていません
+smkwlab/texlive-ja-textlint には、最小限のパッケージしかインストールされていません
 
-もし、smkwlab/texive-ja-textlint 内臓のパッケージだけでは足りない場合、自分で Docker イメージを拡張できます
+もし、smkwlab/texlive-ja-textlint 内臓のパッケージだけでは足りない場合、自分で Docker イメージを拡張できます
 
 tlmgr で任意のパッケージをインストールするには、次のように Dockerfile を作成して、任意のイメージ名でビルドします
 
 ```dockerfile
-FROM smkwlab/texive-ja-textlint:latest
+FROM smkwlab/texlive-ja-textlint:latest
 # XeTeX をインストールする場合の例
 RUN apt-get update \
   && apt-get install -y \


### PR DESCRIPTION
## Summary

Fixed typo in docker image name from 'texive-ja-textlint' to 'texlive-ja-textlint'

## Changes

- **README.md**: Corrected docker pull/tag commands and usage examples
- **docs/usage.md**: Fixed image references and Dockerfile examples

## Impact

This ensures that all documentation uses the correct image name, preventing confusion for users trying to use the container.