### PR TITLE
Add FITpaper.cls support

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -16,7 +16,16 @@ RUN tlmgr install \
   collection-fontsrecommended \
   collection-langjapanese \
   collection-latexextra \
-  latexmk
+  latexmk \
+  jlreq \
+  luatexja \
+  fontspec \
+  unicode-math \
+  newtx \
+  stix2-otf \
+  tex-gyre \
+  haranoaji \
+  lm
 
 FROM alpine:3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715
 ENV PATH /usr/local/bin/texlive:$PATH

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -16,7 +16,16 @@ RUN tlmgr install \
   collection-fontsrecommended \
   collection-langjapanese \
   collection-latexextra \
-  latexmk
+  latexmk \
+  jlreq \
+  luatexja \
+  fontspec \
+  unicode-math \
+  newtx \
+  stix2-otf \
+  tex-gyre \
+  haranoaji \
+  lm
 
 FROM node:20-bookworm-slim
 ENV PATH /usr/local/bin/texlive:/npm/node_modules/.bin:$PATH


### PR DESCRIPTION
## Summary
Add required LaTeX packages to support FITpaper.cls document class compilation in both Alpine and Debian variants.

## Added packages
- `jlreq`: Base document class for Japanese layout
- `luatexja`: Japanese language support for LuaLaTeX
- `fontspec`, `unicode-math`: Unicode font and math support
- `newtx`: Times-compatible fonts
- `stix2-otf`, `tex-gyre`, `haranoaji`, `lm`: Additional font packages

## Test plan
- [x] Compilation test with FITpaper.cls documents
- [x] Verification on both Alpine and Debian variants
- [x] Image size optimization check (approximately 20MB increase)

This change enables compilation of FIT conference papers and other documents using the FITpaper.cls document class.