### PR TITLE
Optimize ARM64 builds to reduce CI time

### DIFF
--- a/.github/workflows/build-arm64-manual.yml
+++ b/.github/workflows/build-arm64-manual.yml
@@ -1,0 +1,49 @@
+name: Build ARM64 Manual
+on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: 'Push image to registry'
+        required: false
+        type: boolean
+        default: false
+      tag:
+        description: 'Tag for the image (only used when push is true)'
+        required: false
+        type: string
+        default: 'test-arm64'
+
+jobs:
+  build-debian-arm64:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      
+      - name: Login to GitHub Container Registry
+        if: ${{ inputs.push }}
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.CR_PAT }}
+      
+      - name: Build Docker image
+        uses: ./.github/actions/build/
+        with:
+          context: ./debian/
+          platforms: linux/arm64
+          load: ${{ !inputs.push }}
+          push: ${{ inputs.push }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ inputs.tag }}
+      
+      - name: Test ARM64 image (local build only)
+        if: ${{ !inputs.push }}
+        run: |
+          echo "Testing ARM64 image locally..."
+          docker run --rm ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ inputs.tag }} \
+            sh -c 'tex --version && tlmgr --version'

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -45,7 +45,7 @@ jobs:
         uses: ./.github/actions/build/
         with:
           context: ./debian/
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:latest

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -50,13 +50,3 @@ jobs:
         with:
           name: debian
           path: ./tests/main.pdf
-  build-debian-arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Build Docker image
-        uses: ./.github/actions/build/
-        with:
-          context: ./debian/
-          platforms: linux/arm64


### PR DESCRIPTION
## Summary
Optimize CI/CD pipeline by reducing ARM64 build frequency to significantly decrease build times while maintaining full platform support for releases.

## Changes
- Remove ARM64 build from PR workflow (saves ~1 hour per PR)
- Build only AMD64 on main branch pushes for faster feedback
- Keep full multi-platform builds for tagged releases
- Add manual ARM64 build workflow for on-demand testing

## Impact
- **PR validation time**: ~60 minutes → ~10 minutes (83% reduction)
- **Main branch builds**: Faster feedback loop with AMD64-only builds
- **Release builds**: No change - still build all platforms
- **ARM64 testing**: Available via manual workflow when needed

## Test plan
- [ ] Verify PR builds complete successfully without ARM64
- [ ] Confirm main branch builds work with AMD64 only
- [ ] Test manual ARM64 workflow execution
- [ ] Ensure tag builds still include all platforms

This optimization maintains our ability to support ARM64 while dramatically improving developer experience with faster CI feedback.