### PR TITLE
Add textlint-rule-terminology support and document ARM64 limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [`alpine`](./alpine/Dockerfile)
   - Only AMD64 supported.
   - AMD64 のみ対応しています
+  - **ARM64制限理由**: TeX Live 2025がaarch64-linuxmusl用バイナリを提供していないため
 - [`latest`](./debian/Dockerfile), [`debian`](./debian/Dockerfile)
   - AMD64, ARM64 supported.
   - AMD64, ARM64 (M1 mac) に対応しています

--- a/alpine/package.json
+++ b/alpine/package.json
@@ -7,6 +7,7 @@
     "textlint-plugin-latex2e": "^1.2.0",
     "textlint-rule-no-mix-dearu-desumasu": "^5.0.0",
     "textlint-rule-preset-ja-spacing": "^2.3.0",
-    "textlint-rule-preset-ja-technical-writing": "^7.0.0"
+    "textlint-rule-preset-ja-technical-writing": "^7.0.0",
+    "textlint-rule-terminology": "^5.0.0"
   }
 }

--- a/debian/package.json
+++ b/debian/package.json
@@ -7,6 +7,7 @@
     "textlint-plugin-latex2e": "^1.2.0",
     "textlint-rule-no-mix-dearu-desumasu": "^5.0.0",
     "textlint-rule-preset-ja-spacing": "^2.3.0",
-    "textlint-rule-preset-ja-technical-writing": "^7.0.0"
+    "textlint-rule-preset-ja-technical-writing": "^7.0.0",
+    "textlint-rule-terminology": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Add `textlint-rule-terminology` to both Alpine and Debian package.json
- Document ARM64 limitations for Alpine images in README
- Enable unified .textlintrc configuration across ecosystem

## Changes
1. **Package Dependencies**: Add `textlint-rule-terminology@^5.0.0` to:
   - `alpine/package.json`
   - `debian/package.json`

2. **Documentation**: Add ARM64 limitation explanation for Alpine images
   - TeX Live 2025 doesn't provide aarch64-linuxmusl binaries
   - Clarifies platform support differences between Alpine and Debian

## Benefits
- Enables terminology rule for technical term standardization
- Supports unified .textlintrc configuration across all ecosystem templates
- Better user understanding of platform limitations

## Test plan
- [x] Verify package.json syntax is valid
- [x] Confirm GitHub Actions build completes successfully
- [x] Test terminology rule functionality with new images
- [x] Validate documentation clarity