### PR TITLE
Add automated README update issue workflow

### DIFF
--- a/.github/workflows/update-readme-issue.yml
+++ b/.github/workflows/update-readme-issue.yml
@@ -1,0 +1,52 @@
+---
+name: Create README Update Issue
+on:
+  workflow_run:
+    workflows: ["Build tag"]
+    types:
+      - completed
+
+jobs:
+  create-readme-issue:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Extract tag name
+        id: tag
+        run: |
+          # Get the tag name from the workflow run
+          TAG_NAME="${{ github.event.workflow_run.head_branch }}"
+          TAG_NAME="${TAG_NAME#refs/tags/}"
+          echo "name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Create Issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tagName = '${{ steps.tag.outputs.name }}';
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Update README.md for ${tagName} release`,
+              body: `## 📝 README.md Update Required
+
+            The \`${tagName}\` tag has been successfully built and released.
+            Please update README.md to reflect the new version.
+
+            ### Checklist
+            - [ ] Update version tags in "Supported tags" section
+            - [ ] Update Docker pull commands
+            - [ ] Update usage examples
+            - [ ] Verify all \`${tagName}\` references are consistent
+
+            ### Locations to update
+            - \`## Supported tags / タグ一覧\`
+            - \`docker pull ghcr.io/smkwlab/texlive-ja-textlint:...\`
+            - \`docker run\` examples
+
+            ### Note
+            Remember to maintain consistency across all version references.`,
+              labels: ['documentation', 'release']
+            });

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 ## Supported tags / タグ一覧
 
 ### Architecture-Optimized Tags (推奨)
-- [`latest`, `2025b`](./debian/Dockerfile) (**アーキテクチャ最適化**)
+- [`latest`, `2025e`](./debian/Dockerfile) (**アーキテクチャ最適化**)
   - AMD64: Alpine-based (軽量・高速)
   - ARM64: Debian-based (互換性重視)
   - 透明なアーキテクチャ選択: 同じタグで最適なイメージを自動取得
 
 ### Traditional Tags (従来タグ)
-- [`alpine`, `2025b-alpine`](./alpine/Dockerfile)
+- [`alpine`, `2025e-alpine`](./alpine/Dockerfile)
   - AMD64のみ対応
   - **ARM64制限理由**: TeX Live 2025がaarch64-linuxmusl用バイナリを提供していないため
-- [`debian`, `2025b-debian`](./debian/Dockerfile)
+- [`debian`, `2025e-debian`](./debian/Dockerfile)
   - AMD64, ARM64 (Apple Silicon) 対応
 
 ## Install / インストール
@@ -25,9 +25,9 @@ GitHub Container Registry からインストールできます。
 
 ```bash
 # 推奨: アーキテクチャ最適化イメージ
-docker pull ghcr.io/smkwlab/texlive-ja-textlint:2025b
+docker pull ghcr.io/smkwlab/texlive-ja-textlint:2025e
 
-# 最新版（2025bと同じ）
+# 最新版（2025eと同じ）
 docker pull ghcr.io/smkwlab/texlive-ja-textlint:latest
 ```
 
@@ -35,7 +35,7 @@ docker pull ghcr.io/smkwlab/texlive-ja-textlint:latest
 
 ```bash
 # アーキテクチャ最適化イメージ使用（推奨）
-$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:2025b \
+$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:2025e \
     sh -c 'latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex'
 
 # latest タグでも同じ結果


### PR DESCRIPTION
## Summary
- Add workflow to automatically create issue when new tag is released
- Update README.md to 2025e in preparation for next release
- Improve release process documentation flow

## Changes
1. **New workflow**: `.github/workflows/update-readme-issue.yml`
   - Triggers on successful tag build
   - Creates issue with README update checklist
   - Provides clear guidance on what to update

2. **README update**: Updated version from 2025b to 2025e
   - Reflects upcoming release with terminology rule support
   - Maintains consistency across all version references

## Benefits
- No more forgotten README updates
- Clear reminders after each release
- Human review ensures quality
- No risk of automated update errors

## Test plan
- [x] Validated workflow syntax with yamllint
- [x] Checked GitHub Actions syntax with actionlint
- [x] Verified shellcheck warnings resolved
- [ ] Will test with next tag release