### PR TITLE
Add automated GitHub Release creation

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -96,7 +96,8 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ github.ref_name }}-alpine-amd64 \
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ github.ref_name }}-debian-arm64
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b # v1
+        uses: softprops/action-gh-release@69e5d0b # v2.0.0
+        continue-on-error: true
         with:
           tag_name: ${{ github.ref_name }}
           name: TeXLive-ja-textlint ${{ github.ref_name }}

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-alpine, build-debian, build-debian-arm64]
     permissions:
-      contents: read
+      contents: write  # Required for release creation
       packages: write
     steps:
       - name: Checkout
@@ -95,3 +95,36 @@ jobs:
           docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:latest \
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ github.ref_name }}-alpine-amd64 \
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ github.ref_name }}-debian-arm64
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b # v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: TeXLive-ja-textlint ${{ github.ref_name }}
+          body: |
+            ## 🐳 Docker Images
+            
+            ### Pull the images
+            ```bash
+            # Architecture-optimized (recommended)
+            docker pull ghcr.io/smkwlab/texlive-ja-textlint:${{ github.ref_name }}
+            
+            # Latest tag
+            docker pull ghcr.io/smkwlab/texlive-ja-textlint:latest
+            
+            # Platform-specific tags
+            docker pull ghcr.io/smkwlab/texlive-ja-textlint:${{ github.ref_name }}-alpine  # Alpine (AMD64 only)
+            docker pull ghcr.io/smkwlab/texlive-ja-textlint:${{ github.ref_name }}-debian  # Debian (Multi-arch)
+            ```
+            
+            ### Quick usage
+            ```bash
+            docker run --rm -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:${{ github.ref_name }} \
+              latexmk main.tex
+            ```
+            
+            ### What's included
+            - TeXLive 2025 with full Japanese support
+            - textlint with Japanese academic writing rules
+            - Architecture-optimized builds (Alpine for AMD64, Debian for ARM64)
+            
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
Add automated GitHub Release creation when tags are pushed, providing better visibility and documentation for each release.

## Changes
- Add `Create GitHub Release` step to `build-tag.yml`
- Update permissions to include `contents: write` for release creation
- Include comprehensive Docker usage instructions in release notes
- Auto-generate changelog from PR history

## Release Notes Content
Each release will automatically include:
- 🐳 Docker image pull commands for all variants
- Quick usage examples
- List of what's included in the images
- Auto-generated changelog from merged PRs

## Benefits
- Users can easily find release information on GitHub Releases page
- Clear documentation of how to use each release
- Automatic changelog generation saves manual work
- Better discoverability of project releases

## Test Plan
- [x] Verify workflow syntax
- [ ] Will be tested with next tag release (e.g., 2025f)
- [ ] Confirm release appears on GitHub Releases page
- [ ] Verify Docker commands in release notes are correct